### PR TITLE
Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.3.0] - 2023-09-03
+
+Changes
+
+- `ImmutableStructExRedactable::Configuration#whitelist` is now supported. Attributes added to #whitelist will not be redacted. All other attributes will be redacted.
+- `ImmutableStructExRedactable::Configuration#redacted` will be deprecated in a future release. Please use `ImmutableStructExRedactable::Configuration#blacklist` instead.
+
 ## [1.2.2] - 2023-08-29
 
 Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     coderay (1.1.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    immutable_struct_ex (1.0.1)
+    immutable_struct_ex (1.0.2)
     json (2.6.3)
     kwalify (0.7.2)
     language_server-protocol (3.17.0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    immutable_struct_ex_redactable (1.2.2)
+    immutable_struct_ex_redactable (1.3.0)
       immutable_struct_ex (~> 1.0, >= 1.0.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Follow the instructions for [Installation](#installation) first, to incorporate 
 
 ```ruby
 ImmutableStructExRedactable::configure do |config|
-  config.redacted = %i[password dob ssn phone]
+  config.blacklist = %i[password dob ssn phone]
   config.redacted_label = '[REDACTED]'
 end
 
@@ -67,7 +67,7 @@ To override the global configuration options, you may do so by calling the `Immu
 ```ruby
 # Create a custom configuration with the options you want to use.
 custom_config = ImmutableStructExRedactable::Configuration.new.tap do |config|
-  config.redacted = %i[password dob]
+  config.blacklist = %i[password dob]
   config.redacted_label = '[NO WAY JOSE]'
 end
 
@@ -85,7 +85,7 @@ ImmutableStructExRedactable.create_with(custom_config, **fields)
 
 ### Access to the Original Redacted Field Values
 
-By default, *immutable_struct_ex_redactable* **will not** allow access to redacted field values; that is, field values marked for redaction via the global configuration (`ImmutableStructExRedactable::Configuration#redacted`) or by overriding the global configuration by passing a custom configuration (`ImmutableStructExRedactable.create_with(my_config, ...)`). However, if you really *need* access to redacted field values in their original, *un*redacted form, you can turn on the `ImmutableStructExRedactable::Configuration#redacted_unsafe` option in the global configuration or turn this same option on when passing a custom configuration. Turning the `redacted_unsafe` configuration option on in either scenario will instruct *immutable_struct_ex_redactable* to create *private methods* on structs created that will allow access to the original *un*redacted field values via `send:`. The *private methods* created that will allow access to the original *un*redacted field values, will have the following naming convention:
+By default, *immutable_struct_ex_redactable* **will not** allow access to redacted field values; that is, field values marked for redaction via the global configuration (`ImmutableStructExRedactable::Configuration#blacklist`) or by overriding the global configuration by passing a custom configuration (`ImmutableStructExRedactable.create_with(my_config, ...)`). However, if you really *need* access to redacted field values in their original, *un*redacted form, you can turn on the `ImmutableStructExRedactable::Configuration#redacted_unsafe` option in the global configuration or turn this same option on when passing a custom configuration. Turning the `redacted_unsafe` configuration option on in either scenario will instruct *immutable_struct_ex_redactable* to create *private methods* on structs created that will allow access to the original *un*redacted field values via `send:`. The *private methods* created that will allow access to the original *un*redacted field values, will have the following naming convention:
 
 ```ruby
 unredacted_<redacted field>

--- a/immutable_struct_ex_redactable.gemspec
+++ b/immutable_struct_ex_redactable.gemspec
@@ -34,4 +34,14 @@ Gem::Specification.new do |spec|
   # Uncomment to register a new dependency of your gem
   spec.add_dependency 'immutable_struct_ex', '~> 1.0', '>= 1.0.1'
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  spec.post_install_message = <<~POST_INSTALL
+    Thank you for installing immutable_struct_ex_redactable.
+
+    immutable_struct_ex_redactable now supports `ImmutableStructExRedactable::Configuration#whitelist`
+    See the README.md for more information.
+
+    Please note that `ImmutableStructExRedactable::Configuration#redacted` will be deprecated in a future release.
+    Please use `ImmutableStructExRedactable::Configuration#blacklist` instead.
+  POST_INSTALL
 end

--- a/lib/immutable_struct_ex_redactable.rb
+++ b/lib/immutable_struct_ex_redactable.rb
@@ -21,7 +21,7 @@ module ImmutableStructExRedactable
         redacted_accessible_module_for(hash: hash, config: config)
     end
 
-    config.redacted.each do |attr|
+    config.blacklist.each do |attr|
       next unless hash.key? attr
 
       hash[attr] = config.redacted_label

--- a/lib/immutable_struct_ex_redactable.rb
+++ b/lib/immutable_struct_ex_redactable.rb
@@ -21,10 +21,18 @@ module ImmutableStructExRedactable
         redacted_accessible_module_for(hash: hash, config: config)
     end
 
-    config.blacklist.each do |attr|
-      next unless hash.key? attr
+    if config.whitelist.any?
+      hash.each do |key, _|
+        next if config.whitelist.include? key
 
-      hash[attr] = config.redacted_label
+        hash[key] = config.redacted_label
+      end
+    else
+      config.blacklist.each do |attr|
+        next unless hash.key? attr
+
+        hash[attr] = config.redacted_label
+      end
     end
 
     ImmutableStructEx.new(**hash, &block).tap do |struct|

--- a/lib/immutable_struct_ex_redactable/configuration.rb
+++ b/lib/immutable_struct_ex_redactable/configuration.rb
@@ -24,12 +24,21 @@ module ImmutableStructExRedactable
   # This class encapsulates the configuration properties for this gem and
   # provides methods and attributes that allow for management of the same.
   class Configuration
-    # Gets/sets the fields that should be redacted for this gem.
+    # Gets/sets the blacklisted fields that should be redacted for this gem.
     #
     # The default is %i[password].
     #
     # @return [Array<Symbol>] an Array of Symbols that should be redacted.
-    attr_accessor :redacted
+    attr_accessor :blacklist
+    alias redacted blacklist
+    alias redacted= blacklist=
+
+    # Gets/sets the whitelisted fields that should not be redacted for this gem.
+    #
+    # The default is [].
+    #
+    # @return [Array<Symbol>] an Array of Symbols that should be whitelisted.
+    attr_accessor :whitelist
 
     # Gets/sets the label that should replace redacted field values.
     #
@@ -62,7 +71,8 @@ module ImmutableStructExRedactable
     #
     # @return [void]
     def reset
-      @redacted = %i[password]
+      @blacklist = %i[password]
+      @whitelist = []
       @redacted_label = '******'
       @redacted_unsafe = false
     end

--- a/lib/immutable_struct_ex_redactable/redacted_accessible.rb
+++ b/lib/immutable_struct_ex_redactable/redacted_accessible.rb
@@ -11,15 +11,30 @@ module ImmutableStructExRedactable
     module ClassModules
       def redacted_accessible_module_for(hash:, config:)
         Module.new do
-          config.blacklist.each do |attr|
-            unredacted_attr_method = "unredacted_#{attr}"
-            code = <<~CODE
-              def #{unredacted_attr_method}
-                "#{hash[attr]}"
-              end
-              private :#{unredacted_attr_method}
-            CODE
-            class_eval code
+          if config.whitelist.any?
+            hash.each do |attr, _|
+              next if config.whitelist.include? attr
+
+              unredacted_attr_method = "unredacted_#{attr}"
+              code = <<~CODE
+                def #{unredacted_attr_method}
+                  "#{hash[attr]}"
+                end
+                private :#{unredacted_attr_method}
+              CODE
+              class_eval code
+            end
+          else
+            config.blacklist.each do |attr|
+              unredacted_attr_method = "unredacted_#{attr}"
+              code = <<~CODE
+                def #{unredacted_attr_method}
+                  "#{hash[attr]}"
+                end
+                private :#{unredacted_attr_method}
+              CODE
+              class_eval code
+            end
           end
         end
       end

--- a/lib/immutable_struct_ex_redactable/redacted_accessible.rb
+++ b/lib/immutable_struct_ex_redactable/redacted_accessible.rb
@@ -11,7 +11,7 @@ module ImmutableStructExRedactable
     module ClassModules
       def redacted_accessible_module_for(hash:, config:)
         Module.new do
-          config.redacted.each do |attr|
+          config.blacklist.each do |attr|
             unredacted_attr_method = "unredacted_#{attr}"
             code = <<~CODE
               def #{unredacted_attr_method}

--- a/lib/immutable_struct_ex_redactable/version.rb
+++ b/lib/immutable_struct_ex_redactable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ImmutableStructExRedactable
-  VERSION = '1.2.2'
+  VERSION = '1.3.0'
 end

--- a/spec/immutable_struct_ex_redactable_spec.rb
+++ b/spec/immutable_struct_ex_redactable_spec.rb
@@ -1,19 +1,40 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'there is private method access to redacted field values' do
+RSpec.shared_examples 'there is private method access to blacklisted field values' do
   it 'adds private methods to access the redacted field values' do
     expect(
-      redacted.all? do |field|
+      blacklist.all? do |field|
         subject.send(:"unredacted_#{field}") == hash[field]
       end
     ).to be true
   end
 end
 
-RSpec.shared_examples 'there is no private method access to unredacted field values' do
+RSpec.shared_examples 'there is no private method access to blacklisted field values' do
   it 'does not add private methods to access the unredacted field values' do
     subject_private_methods = subject.private_methods
-    expect((redacted - hash.keys).any? do |field|
+    expect((blacklist - hash.keys).any? do |field|
+             subject_private_methods.include? :"unredacted_#{field}"
+           end).to be false
+  end
+end
+
+RSpec.shared_examples 'there is private method access to non-whitelisted field values' do
+  it 'adds private methods to access the redacted field values' do
+    expect(
+      hash.keys.all? do |field|
+        next true if whitelist.include? field
+
+        subject.send(:"unredacted_#{field}") == hash[field]
+      end
+    ).to be true
+  end
+end
+
+RSpec.shared_examples 'there is no private method access to non-whitelisted field values' do
+  it 'does not add private methods to access the unredacted field values' do
+    subject_private_methods = subject.private_methods
+    expect((whitelist - hash.keys).any? do |field|
              subject_private_methods.include? :"unredacted_#{field}"
            end).to be false
   end
@@ -50,31 +71,52 @@ RSpec.describe ImmutableStructExRedactable do
       described_class.create(**hash)
     end
 
-    context 'with no redacted fields configured' do
+    context 'with no blacklist and no whitelist fields configured' do
       before do
         described_class.configure do |config|
-          config.redacted = %i[]
+          config.blacklist = []
+          config.whitelist = []
         end
       end
 
       it_behaves_like 'there are no redacted field values'
     end
 
-    context 'with redacted fields configured' do
+    context 'with blacklisted fields configured' do
       before do
         described_class.configure do |config|
-          config.redacted = %i[password ssn dob email]
+          config.blacklist = %i[password ssn dob email]
         end
       end
 
-      it 'redacts the correct field values' do
+      it 'redacts the blacklisted field values' do
         expect(create.password).to eq config.redacted_label
         expect(create.ssn).to eq config.redacted_label
         expect(create.dob).to eq config.redacted_label
         expect(create.email).to eq config.redacted_label
       end
 
-      it 'does not redact non-redacted field values' do
+      it 'does not redact non-blacklisted field values' do
+        expect(create.first).to eq hash[:first]
+        expect(create.last).to eq hash[:last]
+      end
+    end
+
+    context 'with whitelisted fields configured' do
+      before do
+        described_class.configure do |config|
+          config.whitelist = %i[first last]
+        end
+      end
+
+      it 'redacts the non-whitelisted field values' do
+        expect(create.password).to eq config.redacted_label
+        expect(create.ssn).to eq config.redacted_label
+        expect(create.dob).to eq config.redacted_label
+        expect(create.email).to eq config.redacted_label
+      end
+
+      it 'does not redact whitelisted field values' do
         expect(create.first).to eq hash[:first]
         expect(create.last).to eq hash[:last]
       end
@@ -102,18 +144,32 @@ RSpec.describe ImmutableStructExRedactable do
 
       before do
         described_class.configure do |config|
-          config.redacted = redacted
+          config.blacklist = blacklist
+          config.whitelist = whitelist
           config.redacted_label = redacted_label
           config.redacted_unsafe = redacted_unsafe
         end
       end
 
-      let(:redacted) { %i[password email dob ssn] }
-      let(:redacted_unsafe) { true }
-      let(:redacted_label) { '[redacted]' }
+      context 'when a blacklist is configured' do
+        let(:blacklist) { %i[password email dob ssn] }
+        let(:whitelist) { [] }
+        let(:redacted_unsafe) { true }
+        let(:redacted_label) { '[redacted]' }
 
-      it_behaves_like 'there is private method access to redacted field values'
-      it_behaves_like 'there is no private method access to unredacted field values'
+        it_behaves_like 'there is private method access to blacklisted field values'
+        it_behaves_like 'there is no private method access to blacklisted field values'
+      end
+
+      context 'when a whitelist is configured' do
+        let(:blacklist) { [] }
+        let(:whitelist) { %i[first last] }
+        let(:redacted_unsafe) { true }
+        let(:redacted_label) { '[redacted]' }
+
+        it_behaves_like 'there is private method access to non-whitelisted field values'
+        it_behaves_like 'there is no private method access to non-whitelisted field values'
+      end
     end
   end
 
@@ -122,37 +178,79 @@ RSpec.describe ImmutableStructExRedactable do
       described_class.create_with(config, **hash)
     end
 
-    let(:config) do
-      described_class::Configuration.new.tap do |config|
-        config.redacted = redacted
-        config.redacted_label = redacted_label
+    context 'when a blacklist is configured' do
+      let(:config) do
+        described_class::Configuration.new.tap do |config|
+          config.blacklist = blacklist
+          config.redacted_label = redacted_label
+        end
+      end
+      let(:blacklist) { %i[first last] }
+      let(:redacted_label) { 'x' }
+
+      context 'with no blacklisted fields configured' do
+        let(:blacklist) { [] }
+
+        it 'does not redact any field values' do
+          expect(create_with.first).to eq hash[:first]
+          expect(create_with.last).to eq hash[:last]
+          expect(create_with.password).to eq hash[:password]
+          expect(create_with.ssn).to eq hash[:ssn]
+          expect(create_with.dob).to eq hash[:dob]
+        end
+      end
+
+      context 'with blacklist fields configured' do
+        it 'redacts the correct field values' do
+          expect(create_with.first).to eq config.redacted_label
+          expect(create_with.last).to eq config.redacted_label
+        end
+
+        it 'does not redact non-redacted field values' do
+          expect(create_with.password).to eq hash[:password]
+          expect(create_with.ssn).to eq hash[:ssn]
+          expect(create_with.dob).to eq hash[:dob]
+        end
       end
     end
-    let(:redacted) { %i[first last] }
-    let(:redacted_label) { 'x' }
 
-    context 'with no redacted fields configured' do
-      let(:redacted) { %i[] }
-
-      it 'does not redact any field values' do
-        expect(create_with.first).to eq hash[:first]
-        expect(create_with.last).to eq hash[:last]
-        expect(create_with.password).to eq hash[:password]
-        expect(create_with.ssn).to eq hash[:ssn]
-        expect(create_with.dob).to eq hash[:dob]
+    context 'when a whitelist is configured' do
+      let(:config) do
+        described_class::Configuration.new.tap do |config|
+          config.whitelist = whitelist
+          config.redacted_label = redacted_label
+        end
       end
-    end
+      let(:redacted_label) { 'x' }
 
-    context 'with redacted fields configured' do
-      it 'redacts the correct field values' do
-        expect(create_with.first).to eq config.redacted_label
-        expect(create_with.last).to eq config.redacted_label
+      context 'with no whitelisted fields configured' do
+        let(:whitelist) { [] }
+
+        it 'redacts password by default' do
+          expect(create_with.password).to eq config.redacted_label
+        end
+
+        it 'does not redact any other field values' do
+          expect(create_with.first).to eq hash[:first]
+          expect(create_with.last).to eq hash[:last]
+          expect(create_with.ssn).to eq hash[:ssn]
+          expect(create_with.dob).to eq hash[:dob]
+        end
       end
 
-      it 'does not redact non-redacted field values' do
-        expect(create_with.password).to eq hash[:password]
-        expect(create_with.ssn).to eq hash[:ssn]
-        expect(create_with.dob).to eq hash[:dob]
+      context 'with whitelisted fields configured' do
+        let(:whitelist) { %i[first last] }
+
+        it 'redacts the correct field values' do
+          expect(create_with.password).to eq config.redacted_label
+          expect(create_with.ssn).to eq config.redacted_label
+          expect(create_with.dob).to eq config.redacted_label
+        end
+
+        it 'does not redact non-redacted field values' do
+          expect(create_with.first).to eq hash[:first]
+          expect(create_with.last).to eq hash[:last]
+        end
       end
     end
 


### PR DESCRIPTION
## [1.3.0] - 2023-09-03

Changes

- `ImmutableStructExRedactable::Configuration#whitelist` is now supported. Attributes added to #whitelist will not be redacted. All other attributes will be redacted.
- `ImmutableStructExRedactable::Configuration#redacted` will be deprecated in a future release. Please use `ImmutableStructExRedactable::Configuration#blacklist` instead.